### PR TITLE
Support revert-buffer function in devdocs-mode

### DIFF
--- a/devdocs.el
+++ b/devdocs.el
@@ -230,6 +230,7 @@ This is an alist containing `entries' and `types'."
    browse-url-browser-function 'devdocs--browse-url
    buffer-undo-list t
    header-line-format devdocs-header-line
+   revert-buffer-function 'devdocs--revert-buffer
    truncate-lines t))
 
 (defun devdocs-goto-target ()
@@ -339,6 +340,10 @@ fragment part of ENTRY.path."
       (push entry devdocs--stack)
       (devdocs-goto-target)
       (current-buffer))))
+
+(defun devdocs--revert-buffer (&rest _args)
+  "Refresh DevDocs buffer."
+  (devdocs--render (pop devdocs--stack)))
 
 (defun devdocs--browse-url (url &rest args)
   "A suitable `browse-url-browser-function' for `devdocs-mode'.


### PR DESCRIPTION
`devdocs-mode` is derived from `special-mode`, meaning some keybinding are present by default like `h` to display the mode help, `q` to close the window, and `g` to revert it. However, contrary to the 2 firsts, this one by default try to reopen some file, what leads to a crash when the buffer is not associated with any file. Thus currently, the `devdocs-mode`expose the `revert-buffer` behavior in its documentation, but using it leads to a crash.

This MR adds the necessary local variable, mapped to a simple wrapper function for `devdocs--render` to make that keybinding work as expected.

This feature is really needed anyway, for exemple to quickly and easily reflow shr content when changing the frame geometry.