### PR TITLE
Use native JSON parsing availible in Emacs 27 and report progress

### DIFF
--- a/devdocs.el
+++ b/devdocs.el
@@ -152,7 +152,7 @@ If necessary, download data from `devdocs-site-url'."
    (with-temp-buffer
      (url-insert-file-contents
       (format "%s/docs.json" devdocs-site-url))
-     (json-read))))
+     (json-parse-buffer :object-type 'alist))))
 
 (defun devdocs--doc-title (doc)
   "Title of document DOC.
@@ -204,15 +204,16 @@ DOC is a document metadata alist."
          pages)
     (with-temp-buffer
       (url-insert-file-contents (format "%s/%s/db.json?%s" devdocs-cdn-url slug mtime))
-      (dolist (entry (let ((json-key-type 'string))
-                       (json-read)))
+      (dolist-with-progress-reporter
+          (entry (json-parse-buffer  :object-type 'alist))
+          "Downloading DevDocs..."
         (with-temp-file (expand-file-name
                          (url-hexify-string (format "%s.html" (car entry))) temp)
           (push (car entry) pages)
           (insert (cdr entry)))))
     (with-temp-buffer
       (url-insert-file-contents (format "%s/%s/index.json?%s" devdocs-cdn-url slug mtime))
-      (let ((index (json-read)))
+      (let ((index (json-parse-buffer :object-type 'alist)))
         (push `(pages . ,(vconcat (nreverse pages))) index)
         (with-temp-file (expand-file-name "index" temp)
           (prin1 index (current-buffer)))))


### PR DESCRIPTION
Writing a huge amount of HTML files can take a while to finish. Inform
the user about the progress so the user can estimate remaining time
and clearly see that Emacs is busy working, not hung.

Speed Improvement
---------------------------
```elisp
;; Current implementation
(benchmark 1 '(devdocs-install '((name . "PHP") (slug . "php") (type . "php") (links (home . "https://www.php.net/") (code . "https://git.php.net/?p=php-src.git;a=summary")) (release . "8.1.5") (mtime . 1650899439) (db_size . 25993841))))
"Elapsed time: 17.163928s (6.059382s in 93 GCs)"
;; This commit
(benchmark 1 '(devdocs-install '((name . "PHP") (slug . "php") (type . "php") (links (home . "https://www.php.net/") (code . "https://git.php.net/?p=php-src.git;a=summary")) (release . "8.1.5") (mtime . 1650899439) (db_size . 25993841))))
"Elapsed time: 12.833806s (2.523597s in 39 GCs)"
```
