### PR TITLE
[Fix #24] Don't treat symbol at point as a default entry

### DIFF
--- a/devdocs.el
+++ b/devdocs.el
@@ -559,9 +559,9 @@ INITIAL-INPUT is passed to `completing-read'"
                  (if (eq action 'metadata)
                      metadata
                    (complete-with-action action cands string predicate))))
+         (default (car (member (thing-at-point 'symbol) cands)))
          (cand (completing-read prompt coll nil t initial-input
-                                'devdocs-history
-                                (thing-at-point 'symbol))))
+                                'devdocs-history default)))
     (devdocs--get-data (car (member cand cands)))))
 
 ;;;###autoload


### PR DESCRIPTION

There are two ways  to fix the issue:

1. Insert symbol-at-point as the initial-input (this PR)
2. Treat symbol-at-point as the default only when it matches the collection

1 has the disadvantage that the input is inserted by default. Thus the user has to delete the input when she does not want the thing at point. 

2 has the disadvantage that symbol at point won't be part of the candidates. Mostly because the "." separator is not normally considered a symbol in most of the programming modes (don't ask me why). 

I personally slightly prefer 1, but it's your call of course. 