### PR TITLE
fix: URL decodes path fragements, if needed

### DIFF
--- a/devdocs.el
+++ b/devdocs.el
@@ -485,7 +485,7 @@ fragment part of ENTRY.path."
                                             (url-hexify-string (devdocs--path-file .path)))
                                     devdocs-data-dir)))
         (erase-buffer)
-        (setq-local shr-target-id (or .fragment (devdocs--path-fragment .path)))
+        (setq-local shr-target-id (url-unhex-string (or .fragment (devdocs--path-fragment .path))))
         ;; TODO: cl-progv here for shr settings?
         (shr-insert-document
          (with-temp-buffer


### PR DESCRIPTION
Why?:
- When looking up documentation for the Nim language, the ID for a specific function for example is an URL encoded anchor fragment. `text-property-search-forward` does not URL decode the fragment, so the ID won't be found inside the rendered text and we're always stuck at the top.

This change addresses the need by:
- Call url-unhex-string on the argument for setting shr-target-id


Honestly, I'm not too sure if this is the right way to do it, but if the fragment or path fragment is not URL encoded it shouldn't do any harm (at least in the tests I did). I also don't know if it might not be better to URL decode the path fragments when installing a document. I'm open for suggestions.