### PR TITLE
Make mathjax dependency optional

### DIFF
--- a/devdocs.el
+++ b/devdocs.el
@@ -34,7 +34,7 @@
 
 ;;; Code:
 
-(require 'mathjax)
+(require 'mathjax nil t)
 (require 'seq)
 (require 'shr)
 (require 'url-expand)


### PR DESCRIPTION
Even if the mathjax package is "optional" via `devdocs-use-mathjax` it is not really optional since this require call is here.

I propose making the require optional. Alternatively split out the `mathjax` functionality to a separate file (e.g. `devdocs-mathjax`).