### PR TITLE
Remove hard dependency on `mathjax`

### DIFF
--- a/devdocs.el
+++ b/devdocs.el
@@ -5,7 +5,7 @@
 ;; Author: Augusto Stoffel <arstoffel@gmail.com>
 ;; Keywords: help
 ;; URL: https://github.com/astoff/devdocs.el
-;; Package-Requires: ((emacs "27.1") (compat "29.1") (mathjax "0.1"))
+;; Package-Requires: ((emacs "27.1") (compat "29.1"))
 ;; Version: 0.6.1
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/devdocs.el
+++ b/devdocs.el
@@ -34,7 +34,6 @@
 
 ;;; Code:
 
-(require 'mathjax)
 (require 'seq)
 (require 'shr)
 (require 'url-expand)
@@ -124,7 +123,10 @@ experimental and may change in the future.")
                         'devdocs--rendering-functions
                         "0.7")
 
-(defcustom devdocs-use-mathjax (mathjax-available-p)
+(defcustom devdocs-use-mathjax
+  (if (fboundp 'mathjax-available-p)
+      (mathjax-available-p)
+    nil)
   "Whether to render mathematical formulas using MathJax.
 Set this to `block' to render only displayed formulas.  Any other
 non-nil value means to render displayed as well as inline formulas.
@@ -603,6 +605,7 @@ fragment part of ENTRY.path."
     (when (pcase devdocs-use-mathjax
             ('block (string= (dom-attr dom 'display) 'block))
             (_ devdocs-use-mathjax))
+      (require 'mathjax)
       (mathjax-display start (point) dom
                        :after (unless (and (boundp 'shr-fill-text) ;Emacs≥30
                                            (not shr-fill-text))


### PR DESCRIPTION
Hi, thank you for working on this package.

According to one of the customization options for `devdocs-use-mathjax`, `devdocs.el` is capable of rendering math as plain text, the package however calls `(require 'mathjax)` at the top of the package and explicitly references a possibly unbound function `mathjax-available-p` (assuming of course `mathjax` is not installed).

I made some changes to make the `mathjax` feature dependent on whether or not `devdocs-use-mathjax` is `nil` such that the docstring for `devdocs-use-mathjax` aligns with the expected behavior.