### PR TITLE
New completion annotations and a minor improvement to aesthetics

### DIFF
--- a/devdocs.el
+++ b/devdocs.el
@@ -215,7 +215,7 @@ otherwise, offer only installed documents.
 
 Return a document metadata alist if MULTIPLE is nil; otherwise, a
 list of metadata alists."
-  (let ((cands (mapcar (lambda (it) (cons (alist-get 'slug it) it))
+  (let ((cands (mapcar (lambda (it) (cons (devdocs--doc-title it) it))
                        (if available
                            (devdocs--available-docs)
                          (or (devdocs--installed-docs)
@@ -234,7 +234,7 @@ DOC is a document metadata alist."
     (if (and (file-directory-p dest)
              (file-in-directory-p dest devdocs-data-dir))
         (delete-directory dest t)
-      (user-error "Document `%s' is not installed" (alist-get 'slug doc)))))
+      (user-error "Document \"%s\" is not installed" (devdocs--doc-title doc)))))
 
 ;;;###autoload
 (defun devdocs-install (doc)
@@ -273,7 +273,7 @@ already installed, reinstall it."
                  (file-in-directory-p dest devdocs-data-dir))
         (delete-directory dest t))
       (rename-file (file-name-as-directory temp) dest))
-    (message "Document `%s' installed" slug)))
+    (message "Document \"%s\" installed" (devdocs--doc-title slug))))
 
 ;;;###autoload
 (defun devdocs-update-all ()
@@ -292,7 +292,11 @@ already installed, reinstall it."
                       (devdocs--available-docs)))
               ((y-or-n-p (format "Update %s documents %s?"
                                  (length newer)
-                                 (mapcar (lambda (d) (alist-get 'slug d)) newer)))))
+                                 (string-join
+                                  (mapcar (lambda (d)
+                                            (concat "\"" (devdocs--doc-title d) "\""))
+                                          newer)
+                                  ", ")))))
     (dolist (doc newer)
       (devdocs-install doc))))
 


### PR DESCRIPTION
Hey Augusto, thanks for developing this excellent package! I've made some additions to completion annotations, along with a minor improvement (in my opinion) to aesthetics.

**Changes:**
- When displaying document names to the user in contexts such as completions or minibuffer messages, we now use document titles instead of slugs. Thus, instead of "python~3.13" as a completion candidate, we have "Python 3.13".
- `devdocs--read-entry` previously displayed document annotations in a manner similar to Marginalia without actually using Marginalia's facilities. This is not a problem when using Vertico, but it causes misalignment in annotations when using Emacs' built-in completion buffer. I replaced the existing annotation function with two separate ones, for built-in completion and Marginalia. The built-in completion uses a newly introduced variable `devdocs-annotation-separator` (default: ` ——— `) to separate annotations from completion candidates.
- `devdocs--read-document` now displays detailed version information as annotations for documents. Previously, without such annotations, for some documents it was not possible to know (without going to the DevDocs webpage or downloading the document) the exact versions that were being used. Similar to the above, these annotations support both the built-in completion and Marginalia. If the detailed version information is already present in the document title, we do not display it again as an annotation. Thus, "Python 3.13" has the annotation "3.13.5", but "PyTorch 2.7" has no annotation because the `version` and `release` fields in its metadata are both "2.7".

Here are two screenshots showing the new annotations:
<img width="600" src="https://github.com/user-attachments/assets/772b0f47-b77c-4b2e-9535-7d93ce2863ba" />
<img width="600" src="https://github.com/user-attachments/assets/0a1a46cd-32d5-41f9-892f-60b88472586e" />
